### PR TITLE
Update Curd.php

### DIFF
--- a/app/command/Curd.php
+++ b/app/command/Curd.php
@@ -11,6 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Curd extends Command
 {
 
+    protected static $defaultName = 'curd';
+    protected static $defaultDescription = '快速生成CURD的命令, 包括控制器、视图、模型、JS文件.';
+
     protected function configure()
     {
         $this->setName('curd')->addOption('table', 't', InputOption::VALUE_REQUIRED, '数据库表名');


### PR DESCRIPTION
添加curd的命令默认名称和描述，否则执行php webman会报异常： Uncaught RuntimeException: Command app\command\Curd has no defaultName